### PR TITLE
Add a release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,20 @@
 ---
-name: go
+name: Build & Test
 
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Allow this workflow be reused (for example in the release pipeline)
+  workflow_call:
 
 jobs:
-
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
+          cache: true
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   push:
-    branches: [ github-release-pipeline ]
     tags: [ 'v*' ]
 
 permissions:
@@ -49,6 +48,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist --snapshot
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    branches: [ github-release-pipeline ]
     tags: [ 'v*' ]
 
 permissions:
@@ -48,6 +49,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+permissions:
+  contents: read
+
+jobs:
+  build-before-release:
+    uses: ./.github/workflows/ci.yml
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build-before-release
+    permissions:
+      contents: write # needed to write releases
+      packages: write # needed for ghcr access
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --force --tags
+
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+          cache: true
+
+      # Those are needed so goreleaser can build multi-arch docker images
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Finally run the release
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /tuwat
 /config.toml
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,7 +68,7 @@ archives:
 
 dockers:
   - image_templates:
-      - "synyx/tuwat:{{ .Tag }}-amd64"
+      - "synyx/tuwat:{{ .Version }}-amd64"
     use: buildx
     goos: linux
     goarch: amd64
@@ -81,7 +81,7 @@ dockers:
       - "--label=org.opencontainers.image.source={{ .GitURL }}"
       - "--platform=linux/amd64"
   - image_templates:
-      - "synyx/tuwat:{{ .Tag }}-arm64"
+      - "synyx/tuwat:{{ .Version }}-arm64"
     use: buildx
     goos: linux
     goarch: arm64
@@ -95,15 +95,15 @@ dockers:
       - "--platform=linux/arm64"
 
 docker_manifests:
-  - name_template: 'synyx/tuwat:{{ .Tag }}'
+  - name_template: 'synyx/tuwat:{{ .Version }}'
     image_templates:
-      - 'synyx/tuwat:{{ .Tag }}-amd64'
-      - 'synyx/tuwat:{{ .Tag }}-arm64'
+      - 'synyx/tuwat:{{ .Version }}-amd64'
+      - 'synyx/tuwat:{{ .Version }}-arm64'
   # We also move the latest when publishing new images
   - name_template: 'synyx/tuwat:latest'
     image_templates:
-      - 'synyx/tuwat:{{ .Tag }}-amd64'
-      - 'synyx/tuwat:{{ .Tag }}-arm64'
+      - 'synyx/tuwat:{{ .Version }}-amd64'
+      - 'synyx/tuwat:{{ .Version }}-arm64'
 
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,109 @@
+# Before building anything, we need to ensure that go modules and generators are setup correctly
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+# These are the final binaries, that we want to create
+builds:
+  # This first linux build also contains the defaults used for all other platforms
+  - <<: &build_defaults
+      binary: tuwat
+      # The single main entrypoint binary for tuwat
+      main: ./cmd/tuwat
+      env:
+        # We have no C dependencies
+        - CGO_ENABLED=0
+      # We want our builds to be reproducible, so we use the commit time as timestamps
+      mod_timestamp: '{{ .CommitTimestamp }}'
+    id: linux
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - <<: *build_defaults
+    id: darwin
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+  - <<: *build_defaults
+    id: windows
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+# For systems supporting universal binaries (hello Apple!) we ship a single binary
+universal_binaries:
+  - id: darwin
+    ids:
+      - darwin
+    replace: true
+
+# Configure how snapshots are versioned
+snapshot:
+  name_template: '{{ incpatch .Version }}-dev-{{ .ShortCommit }}'
+
+# Configure what goes into the archives
+archives:
+  - <<: &archive_defaults
+      name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+      # Additonally packaged files
+      files:
+        - LICENSE
+        - README*
+        - CHANGELOG*
+        - config.example.toml
+    id: nix
+    builds: [ linux, darwin ]
+    format: tar.gz
+  - <<: *archive_defaults
+    id: windows
+    builds: [ windows ]
+    format: zip
+
+dockers:
+  - image_templates:
+      - "synyx/tuwat:{{ .Tag }}-amd64"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.name={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source={{ .GitURL }}"
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "synyx/tuwat:{{ .Tag }}-arm64"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.name={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source={{ .GitURL }}"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: 'synyx/tuwat:{{ .Tag }}'
+    image_templates:
+      - 'synyx/tuwat:{{ .Tag }}-amd64'
+      - 'synyx/tuwat:{{ .Tag }}-arm64'
+  # We also move the latest when publishing new images
+  - name_template: 'synyx/tuwat:latest'
+    image_templates:
+      - 'synyx/tuwat:{{ .Tag }}-amd64'
+      - 'synyx/tuwat:{{ .Tag }}-arm64'
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM gcr.io/distroless/static-debian11
 
 WORKDIR /go
-COPY ./tuwat /go/tuwat
+COPY ./tuwat /tuwat
 EXPOSE 8988
-ENTRYPOINT ["/go/tuwat"]
+ENTRYPOINT ["/tuwat"]
 
 LABEL org.opencontainers.image.authors="Jonathan Buch <jbuch@synyx.de>" \
       org.opencontainers.image.url="https://github.com/synyx/tuwat" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM scratch
-
-ARG CI_PROJECT_URL
-
-COPY --from=registry.synyx.cloud/gitlabci/golang:latest /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static-debian11
 
 WORKDIR /go
 COPY ./tuwat /go/tuwat
@@ -10,7 +6,7 @@ EXPOSE 8988
 ENTRYPOINT ["/go/tuwat"]
 
 LABEL org.opencontainers.image.authors="Jonathan Buch <jbuch@synyx.de>" \
-      org.opencontainers.image.url=${CI_PROJECT_URL} \
+      org.opencontainers.image.url="https://github.com/synyx/tuwat" \
       org.opencontainers.image.vendor="synyx GmbH & Co. KG" \
       org.opencontainers.image.title="Tuwat Dashboard" \
       org.opencontainers.image.description="Tuwat Operations Dashboard"


### PR DESCRIPTION
This adds new workflows and configuration for a release pipeline.

The pipeline is based on the [GoReleaser](https://goreleaser.com) tools, which are commonly used in the Golang community for releasing software with artifacts attached for multiple architectures.  This PR ensures releases are built for the following targets:

* Major operating systems with their primary architectures
  * Linux (amd64 & arm64)
  * Darwin (amd64 & arm64, packaged as unversal binary)
  * Windows (amd64 & arm64)
* Docker images for Linux
  * Architecture-specific variants `synyx/tuwat:{{ .Tag }}-amd64` and `synyx/tuwat:{{ .Tag }}-arm64`
  * A multi-arch manifest `synyx/tuwat:{{ .Tag}}` and `synyx/tuwat:latest`