### PR TITLE
Add a version information package auto-filled from goreleaser build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
         - -X {{.ModulePath}}/pkg/version.version={{.Version}}
         - -X {{.ModulePath}}/pkg/version.revision={{.FullCommit}}
         - -X {{.ModulePath}}/pkg/version.branch={{.Branch}}
-        - -X {{.ModulePath}}/pkg/version.buildDate={{.Date}}
+        - -X {{.ModulePath}}/pkg/version.releaseDate={{.Date}}
     id: linux
     goos:
       - linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,13 @@ builds:
         - CGO_ENABLED=0
       # We want our builds to be reproducible, so we use the commit time as timestamps
       mod_timestamp: '{{ .CommitTimestamp }}'
+      ldflags:
+        - -s -w
+        - -X {{.ModulePath}}/pkg/version.application={{.Binary}}
+        - -X {{.ModulePath}}/pkg/version.version={{.Version}}
+        - -X {{.ModulePath}}/pkg/version.revision={{.FullCommit}}
+        - -X {{.ModulePath}}/pkg/version.branch={{.Branch}}
+        - -X {{.ModulePath}}/pkg/version.buildDate={{.Date}}
     id: linux
     goos:
       - linux

--- a/cmd/tuwat/main.go
+++ b/cmd/tuwat/main.go
@@ -7,9 +7,9 @@ import (
 	"syscall"
 
 	"github.com/synyx/tuwat/pkg/aggregation"
-	"github.com/synyx/tuwat/pkg/buildinfo"
 	"github.com/synyx/tuwat/pkg/config"
 	"github.com/synyx/tuwat/pkg/log"
+	"github.com/synyx/tuwat/pkg/version"
 	"github.com/synyx/tuwat/pkg/web"
 	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.uber.org/zap"
@@ -23,10 +23,7 @@ func main() {
 	}
 
 	if cfg.PrintVersion {
-		fmt.Print(buildinfo.Version)
-		if buildinfo.GitSHA != "" {
-			fmt.Printf(" (%s)", buildinfo.GitSHA)
-		}
+		fmt.Print(version.Info.Print())
 		fmt.Println()
 		return
 	}

--- a/cmd/tuwat/main.go
+++ b/cmd/tuwat/main.go
@@ -23,8 +23,7 @@ func main() {
 	}
 
 	if cfg.PrintVersion {
-		fmt.Print(version.Info.HumanReadable())
-		fmt.Println()
+		fmt.Println(version.Info.HumanReadable())
 		return
 	}
 

--- a/cmd/tuwat/main.go
+++ b/cmd/tuwat/main.go
@@ -23,7 +23,7 @@ func main() {
 	}
 
 	if cfg.PrintVersion {
-		fmt.Print(version.Info.Print())
+		fmt.Print(version.Info.HumanReadable())
 		fmt.Println()
 		return
 	}

--- a/pkg/buildinfo/version.go
+++ b/pkg/buildinfo/version.go
@@ -1,7 +1,0 @@
-package buildinfo
-
-var (
-	Service = "tuwat"
-	GitSHA  string
-	Version = "dev"
-)

--- a/pkg/connectors/alertmanager/silence.go
+++ b/pkg/connectors/alertmanager/silence.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/synyx/tuwat/pkg/buildinfo"
 	"github.com/synyx/tuwat/pkg/connectors"
+	"github.com/synyx/tuwat/pkg/version"
 )
 
 func (c *Connector) createSilencer(alert connectors.Alert) connectors.SilencerFunc {
@@ -21,6 +21,7 @@ func (c *Connector) createSilencer(alert connectors.Alert) connectors.SilencerFu
 }
 
 func (c *Connector) Silence(ctx context.Context, alert connectors.Alert, duration time.Duration, user string) error {
+
 	payload := map[string]interface{}{
 		"matchers": map[string]interface{}{
 			"name":    "uid",
@@ -30,7 +31,7 @@ func (c *Connector) Silence(ctx context.Context, alert connectors.Alert, duratio
 		"startsAt":  time.Now().Format(time.RFC3339),
 		"endsAt":    time.Now().Add(duration).Format(time.RFC3339),
 		"createdBy": user,
-		"comment":   fmt.Sprintf("%s: silenced via %s", user, buildinfo.Service),
+		"comment":   fmt.Sprintf("%s: silenced via %s", user, version.Info.Application),
 	}
 	endpoint := "/api/v2/silences"
 

--- a/pkg/connectors/icinga2/silence.go
+++ b/pkg/connectors/icinga2/silence.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/synyx/tuwat/pkg/buildinfo"
 	"github.com/synyx/tuwat/pkg/connectors"
+	"github.com/synyx/tuwat/pkg/version"
 )
 
 func (c *Connector) createSilencer(alert connectors.Alert) connectors.SilencerFunc {
@@ -23,7 +23,7 @@ func (c *Connector) createSilencer(alert connectors.Alert) connectors.SilencerFu
 func (c *Connector) Silence(ctx context.Context, alert connectors.Alert, duration time.Duration, user string) error {
 	payload := map[string]interface{}{
 		"type":          alert.Labels["type"],
-		"comment":       fmt.Sprintf("%s: silenced via %s", user, buildinfo.Service),
+		"comment":       fmt.Sprintf("%s: silenced via %s", user, version.Info.Application),
 		"author":        user,
 		"child_options": 1,
 		"start_time":    time.Now().Unix(),

--- a/pkg/connectors/nagiosapi/silence.go
+++ b/pkg/connectors/nagiosapi/silence.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/synyx/tuwat/pkg/buildinfo"
 	"github.com/synyx/tuwat/pkg/connectors"
+	"github.com/synyx/tuwat/pkg/version"
 )
 
 func (c *Connector) createSilencer(alert connectors.Alert) connectors.SilencerFunc {
@@ -24,7 +24,7 @@ func (c *Connector) Silence(ctx context.Context, alert connectors.Alert, duratio
 	payload := map[string]interface{}{
 		"host":    alert.Labels["Hostname"],
 		"service": alert.Description,
-		"comment": fmt.Sprintf("%s: silenced via %s", user, buildinfo.Service),
+		"comment": fmt.Sprintf("%s: silenced via %s", user, version.Info.Application),
 		"author":  user,
 		"expire":  duration / time.Minute,
 	}

--- a/pkg/log/telemetry.go
+++ b/pkg/log/telemetry.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/synyx/tuwat/pkg/buildinfo"
 	"github.com/synyx/tuwat/pkg/config"
 	propagation2 "github.com/synyx/tuwat/pkg/log/propagation"
+	"github.com/synyx/tuwat/pkg/version"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/jaeger"
@@ -56,8 +56,8 @@ func stdoutTracer(cfg *config.Config) (tp *tracesdk.TracerProvider) {
 		tracesdk.WithSyncer(exporter),
 		tracesdk.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(buildinfo.Service),
-			semconv.ServiceVersionKey.String(buildinfo.Version),
+			semconv.ServiceNameKey.String(version.Info.Application),
+			semconv.ServiceVersionKey.String(version.Info.Version),
 			attribute.String("environment", cfg.Environment),
 			attribute.String("instance", cfg.Instance),
 		)),
@@ -89,8 +89,8 @@ func jaegerTracer(cfg *config.Config) *tracesdk.TracerProvider {
 		// Record information about this application in a Resource.
 		tracesdk.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(buildinfo.Service),
-			semconv.ServiceVersionKey.String(buildinfo.Version),
+			semconv.ServiceNameKey.String(version.Info.Application),
+			semconv.ServiceVersionKey.String(version.Info.Version),
 			attribute.String("environment", cfg.Environment),
 			attribute.String("instance", cfg.Instance),
 		)),

--- a/pkg/version/info.go
+++ b/pkg/version/info.go
@@ -34,7 +34,7 @@ var versionInfoTmpl = `
   platform:         {{.GoPlatform}}
 `
 
-func (v VersionInfo) Print() string {
+func (v VersionInfo) HumanReadable() string {
 	t := template.Must(template.New("version").Parse(versionInfoTmpl))
 	var buf bytes.Buffer
 	if err := t.ExecuteTemplate(&buf, "version", v); err != nil {

--- a/pkg/version/info.go
+++ b/pkg/version/info.go
@@ -13,7 +13,7 @@ var (
 	version     = "dev"
 	revision    string
 	branch      string
-	buildDate   string
+	releaseDate string
 )
 
 // A rich representation of the version information which can also be readily serialized into a JSON representation
@@ -22,14 +22,14 @@ type VersionInfo struct {
 	Version     string `json:"version"`
 	Revision    string `json:"revision,omitempty"`
 	Branch      string `json:"branch,omitempty"`
-	BuildDate   string `json:"buildDate,omitempty"`
+	ReleaseDate string `json:"releaseDate,omitempty"`
 	GoVersion   string `json:"goVersion"`
 	GoPlatform  string `json:"goPlatform"`
 }
 
 var versionInfoTmpl = `
 {{.Application}}, version {{.Version}} (branch: {{.Branch}}, revision: {{.Revision}})
-  build date:       {{.BuildDate}}
+  release date:     {{.ReleaseDate}}
   go version:       {{.GoVersion}}
   platform:         {{.GoPlatform}}
 `
@@ -51,7 +51,7 @@ func init() {
 		Version:     version,
 		Revision:    revision,
 		Branch:      branch,
-		BuildDate:   buildDate,
+		ReleaseDate: releaseDate,
 		GoVersion:   runtime.Version(),
 		GoPlatform:  runtime.GOOS + "/" + runtime.GOARCH,
 	}

--- a/pkg/version/info.go
+++ b/pkg/version/info.go
@@ -1,10 +1,8 @@
 package version
 
 import (
-	"bytes"
+	"fmt"
 	"runtime"
-	"strings"
-	"text/template"
 )
 
 // These are mostly set during compilation from linker flags
@@ -27,20 +25,8 @@ type VersionInfo struct {
 	GoPlatform  string `json:"goPlatform"`
 }
 
-var versionInfoTmpl = `
-{{.Application}}, version {{.Version}} (branch: {{.Branch}}, revision: {{.Revision}})
-  release date:     {{.ReleaseDate}}
-  go version:       {{.GoVersion}}
-  platform:         {{.GoPlatform}}
-`
-
 func (v VersionInfo) HumanReadable() string {
-	t := template.Must(template.New("version").Parse(versionInfoTmpl))
-	var buf bytes.Buffer
-	if err := t.ExecuteTemplate(&buf, "version", v); err != nil {
-		panic(err)
-	}
-	return strings.TrimSpace(buf.String())
+	return fmt.Sprintf("%s v%s (release date: %s)", v.Application, v.Version, v.ReleaseDate)
 }
 
 var Info VersionInfo

--- a/pkg/version/info.go
+++ b/pkg/version/info.go
@@ -1,0 +1,58 @@
+package version
+
+import (
+	"bytes"
+	"runtime"
+	"strings"
+	"text/template"
+)
+
+// These are mostly set during compilation from linker flags
+var (
+	application = "tuwat"
+	version     = "dev"
+	revision    string
+	branch      string
+	buildDate   string
+)
+
+// A rich representation of the version information which can also be readily serialized into a JSON representation
+type VersionInfo struct {
+	Application string `json:"application"`
+	Version     string `json:"version"`
+	Revision    string `json:"revision,omitempty"`
+	Branch      string `json:"branch,omitempty"`
+	BuildDate   string `json:"buildDate,omitempty"`
+	GoVersion   string `json:"goVersion"`
+	GoPlatform  string `json:"goPlatform"`
+}
+
+var versionInfoTmpl = `
+{{.Application}}, version {{.Version}} (branch: {{.Branch}}, revision: {{.Revision}})
+  build date:       {{.BuildDate}}
+  go version:       {{.GoVersion}}
+  platform:         {{.GoPlatform}}
+`
+
+func (v VersionInfo) Print() string {
+	t := template.Must(template.New("version").Parse(versionInfoTmpl))
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "version", v); err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+var Info VersionInfo
+
+func init() {
+	Info = VersionInfo{
+		Application: application,
+		Version:     version,
+		Revision:    revision,
+		Branch:      branch,
+		BuildDate:   buildDate,
+		GoVersion:   runtime.Version(),
+		GoPlatform:  runtime.GOOS + "/" + runtime.GOARCH,
+	}
+}

--- a/pkg/web/actuator/info.go
+++ b/pkg/web/actuator/info.go
@@ -2,51 +2,27 @@ package actuator
 
 import (
 	"encoding/json"
+	"github.com/synyx/tuwat/pkg/version"
 	"net/http"
 
-	"github.com/synyx/tuwat/pkg/buildinfo"
 	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.uber.org/zap"
 )
 
-type HealthHandler struct {
+type versionHandler struct {
+	versionInfo *version.VersionInfo
 }
 
-func NewHealthHandler() *HealthHandler {
-	return &HealthHandler{}
+func NewVersionHandler() *versionHandler {
+	return &versionHandler{versionInfo: &version.Info}
 }
 
-type gitCommitInfo struct {
-	Id string `json:"id,omitempty"`
-}
-type gitInfo struct {
-	Commit gitCommitInfo `json:"commit,omitempty"`
-}
-type appInfo struct {
-	Version string `json:"version"`
-	Name    string `json:"name"`
-}
-type info struct {
-	App appInfo `json:"app"`
-	Git gitInfo `json:"git,omitempty"`
-}
-
-func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (v *versionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-
-	info := info{
-		App: appInfo{
-			Version: buildinfo.Version,
-			Name:    buildinfo.Service,
-		},
-	}
-	if buildinfo.GitSHA != "" {
-		info.Git = gitInfo{gitCommitInfo{Id: buildinfo.GitSHA}}
-	}
 
 	encoder := json.NewEncoder(w)
 
-	if err := encoder.Encode(info); err != nil {
+	if err := encoder.Encode(v.versionInfo); err != nil {
 		otelzap.Ctx(r.Context()).Debug("error serving info", zap.Error(err))
 	}
 }

--- a/pkg/web/actuator/info.go
+++ b/pkg/web/actuator/info.go
@@ -2,9 +2,9 @@ package actuator
 
 import (
 	"encoding/json"
-	"github.com/synyx/tuwat/pkg/version"
 	"net/http"
 
+	"github.com/synyx/tuwat/pkg/version"
 	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.uber.org/zap"
 )

--- a/pkg/web/handler.go
+++ b/pkg/web/handler.go
@@ -15,7 +15,7 @@ func Handle(appCtx context.Context, cfg *config.Config, webHandler http.Handler)
 	muxer := newTracedMuxer()
 
 	muxer.Handle("actuator", "/actuator/health", actuator.HealthAggregator)
-	muxer.Handle("actuator", "/actuator/info", actuator.NewHealthHandler())
+	muxer.Handle("actuator", "/actuator/info", actuator.NewVersionHandler())
 	muxer.Handle("actuator", "/actuator/prometheus", promhttp.Handler())
 	muxer.Handle("static", "/static/", http.StripPrefix("/static", newNoListingFileServer(cfg)))
 	muxer.Handle("web", "/", webHandler)

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/synyx/tuwat/pkg/aggregation"
-	"github.com/synyx/tuwat/pkg/buildinfo"
 	"github.com/synyx/tuwat/pkg/config"
+	"github.com/synyx/tuwat/pkg/version"
 	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -139,7 +139,7 @@ func (h *webHandler) baseRenderer(req *http.Request, patterns ...string) renderF
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(statusCode)
 
-		data.Version = buildinfo.Version
+		data.Version = version.Info.Version
 		data.Environment = h.environment
 
 		err := tmpl.ExecuteTemplate(w, templateDefinition, data)
@@ -172,7 +172,7 @@ func (h *webHandler) partialRenderer(req *http.Request, patterns ...string) rend
 		w.Header().Set("Content-Type", "text/vnd.turbo-stream.html")
 		w.WriteHeader(statusCode)
 
-		data.Version = buildinfo.Version
+		data.Version = version.Info.Version
 		data.Environment = h.environment
 
 		err := tmpl.ExecuteTemplate(w, templateDefinition, data)
@@ -220,7 +220,7 @@ func (h *webHandler) sseRenderer(w http.ResponseWriter, req *http.Request, patte
 	flusher.Flush()
 
 	return func(data webContent) {
-		data.Version = buildinfo.Version
+		data.Version = version.Info.Version
 		data.Environment = h.environment
 
 		buf := new(bytes.Buffer)
@@ -276,7 +276,7 @@ func (h *webHandler) wsRenderer(s *websocket.Conn, patterns ...string) wsRenderF
 			panic(err)
 		}
 
-		data.Version = buildinfo.Version
+		data.Version = version.Info.Version
 		data.Environment = h.environment
 
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
This adds automatic version information from the GoReleaser build introduced in #15.

The new `VersionInfo` struct is made available as `version.Info` on application start and can then be used as is, even in a JSON encoding context (example in `pkg/web/actuator/info.go`).