### PR TITLE
make Text on status.red entries more readable

### DIFF
--- a/pkg/web/static/css/main.css
+++ b/pkg/web/static/css/main.css
@@ -102,8 +102,7 @@ th {
 
 .status.red, .status.red summary, .status.red details {
     background-color: #FF4040;
-    color: white;
-    opacity: 0.75;
+    color: whitesmoke;
 }
 
 .status.yellow, .status.yellow summary, .status.yellow details {


### PR DESCRIPTION
on status.red, dont use opacity on white, but use whitesmoke with no opacity (so it can be brightened on hover)