### PR TITLE
Changed the color scheme of the alerts to increase contrast

### DIFF
--- a/pkg/web/static/css/main.css
+++ b/pkg/web/static/css/main.css
@@ -100,7 +100,7 @@ th {
 }
 
 .status.red, .status.red summary, .status.red details {
-    background-color: #FF4040;
+    background-color: #ff5050;
     color: black;
 }
 

--- a/pkg/web/static/css/main.css
+++ b/pkg/web/static/css/main.css
@@ -95,15 +95,13 @@ th {
 }
 
 .status.green, .status.green summary, .status.green details {
-    background-color: #269926;
-    color: white;
-    opacity: 0.75;
+    background-color: #26AC1C;
+    color: black;
 }
 
 .status.red, .status.red summary, .status.red details {
     background-color: #FF4040;
-    color: whitesmoke;
-    opacity: 0.95
+    color: black;
 }
 
 .status.yellow, .status.yellow summary, .status.yellow details {
@@ -114,7 +112,6 @@ th {
 .status.grey, .status.grey summary, .status.grey details {
     background-color: #444444;
     color: whitesmoke;
-    opacity: 0.95
 }
 
 summary {


### PR DESCRIPTION
This is based on contrast ratio, staying close to the recommendations for visual-audio contrast recommendations from W3C (minimum 4.5:1 for small text, 7:1 for small text and users with a lower visual acuity). Red alerts stayed the same bright red for now, as the emphasis is for the alert to be immedialty recognized as important, but changed the text color from white to black for better contrast.

Note that I removed the opacity, as it was actually changing the opacity of the whole alert, instead of just changing the text opacity. I do not know if that was intended or not.

Looking at the examples below, I would highly appreciate a proposition for a different "red", as it still feels a bit hard on the eyes.

Before:
![image](https://github.com/synyx/tuwat/assets/2537226/ae5dffa1-4136-4fe5-bfb6-35c15f9ae12d)


After changes:
![image](https://github.com/synyx/tuwat/assets/2537226/12711589-0478-46eb-a542-1ad060bdf7c4)

W3C source:
https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html
