### PR TITLE
Range rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Releases
 
+## v1.x
+
+* Add a `when` rule to be able to match on when the alert happened.
+* Add more expressive rules, making it possible to express a
+  `greater than` on numerical values.  See `README` for details.
+* Breaking configuration changes:
+  * The `what` rules are now combined via `AND` with label rules.
+    This streamlines the behaviour, making it behave like the label
+    rules themselves.  It also makes it possible e.g. to express that
+    a rule matcher only applies when the alert is old.
+
 ## v1.0 - 2023-10-23 Maintenance
 
 * Revise look of alerts
@@ -45,8 +56,8 @@
 ## v0.14 - 2023-05-16 Stability
 
 * Make management port configurable via `-mgmtAddr :8987`
-* Add net/pprof for debugging, see http://127.0.0.1:8987/debug/pprof
-* Add Down state for health endpoint if last collection too old
+* Add `net/pprof` for debugging, see http://127.0.0.1:8987/debug/pprof
+* Add `Down` state for health endpoint if last collection too old
 
 Breaking Changes:
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Draft = "true"
 
 #### Matching Rules
 
-The default is to match the value in the configuration as a regulra expression.
+The default is to match the value in the configuration as a regular expression.
 However, this can be changed by specifying an operator.
 
 * `~= string`: Explicitly require a regular expression to be matched

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ what = "fooo service"
 ```toml
 [[rule]]
 description = "Ignore Drafts"
+what = "Thing"
+when = "> 60"
 [rule.label]
 Draft = "true"
 ```
@@ -73,7 +75,20 @@ Draft = "true"
 * The `label` section selects items via labels.  In this example it would match
   an item which has the label `Draft` which matches the given regular expression.
 * The label rules will combine as `AND`.
-* `what` rules will combine as `OR` with label rules.
+* `what` rules will combine as `AND` with label rules.
+* `when` rules will combine with `AND` with label and `what` rules.
+
+#### Matching Rules
+
+The default is to match the value in the configuration as a regulra expression.
+However, this can be changed by specifying an operator.
+
+* `~= string`: Explicitly require a regular expression to be matched
+* `= string`: Require the string to exactly match
+* `> number`: Require both configuration and the value in the alert to be a
+  numerical value and that the value in the alert to be bigger than the
+  configured number.
+  This also applies to the `<`, `>=`, `<=` operators.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ The default is to match the value in the configuration as a regular expression.
 However, this can be changed by specifying an operator.
 
 * `~= string`: Explicitly require a regular expression to be matched
-* `= string`: Require the string to exactly match
-* `> number`: Require both configuration and the value in the alert to be a
+* `=  string`: Require the string to exactly match.  In case the value is
+  numeric, this will mean that the value will compared like a floating point
+  value.  This means that differences below `1e-8` will be considered to be
+  the same.
+* `>  number`: Require both configuration and the value in the alert to be a
   numerical value and that the value in the alert to be bigger than the
   configured number.
   This also applies to the `<`, `>=`, `<=` operators.

--- a/pkg/aggregation/aggregator.go
+++ b/pkg/aggregation/aggregator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	html "html/template"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -414,7 +413,7 @@ nextRule:
 			continue nextRule
 		}
 
-		res := make(map[string]*regexp.Regexp)
+		res := make(map[string]config.RuleMatcher)
 
 		// Test if the rule is applicable to the given alert
 		for l, r := range rule.Labels {
@@ -466,7 +465,7 @@ nextRule:
 			continue nextRule
 		}
 
-		res := make(map[string]*regexp.Regexp)
+		res := make(map[string]config.RuleMatcher)
 
 		// Test if the rule is applicable to the given alert
 		for l, r := range rule.Labels {

--- a/pkg/aggregation/aggregator.go
+++ b/pkg/aggregation/aggregator.go
@@ -391,7 +391,7 @@ func (a *Aggregator) allow(dashboard *config.Dashboard, alert Alert) string {
 
 	switch dashboard.Mode {
 	case config.Including:
-		// Revert logic when only dashboard requires only showing matching alerts.
+		// Revert logic when the dashboard configuration is in `including` mode.
 		if reason == "" {
 			return "Unmatched"
 		} else {
@@ -415,14 +415,10 @@ nextRule:
 			// `what` contains a description what is being alerted and should be a
 			// human understandable description.  The rule simply matches against
 			// that.
-			// Continue with other matchers if there is no `what` rule, or it doesn't
-			// match, thus combining with other matchers via OR.
 			matchers[alert.What] = rule.What
 		} else if rule.When != nil {
 			// `when` is a duration, which is converted to seconds.  The rule simply matches against
 			// that.
-			// Continue with other matchers if there is no `when` rule, or it doesn't
-			// match, thus combining with other matchers via OR.
 			seconds := strconv.FormatFloat(alert.When.Seconds(), 'f', 0, 64)
 			matchers[seconds] = rule.When
 		}

--- a/pkg/aggregation/aggregator.go
+++ b/pkg/aggregation/aggregator.go
@@ -437,8 +437,8 @@ nextRule:
 		// If all the applicable matchers return a match, this rule matches,
 		// meaning the rules are combined via `AND`.
 		matchCount := 0
-		for val, matcher := range matchers {
-			if matcher.MatchString(val) {
+		for alertValue, matcher := range matchers {
+			if matcher.MatchString(alertValue) {
 				matchCount++
 			}
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,7 @@ type Dashboard struct {
 type Rule struct {
 	Description string
 	What        RuleMatcher
+	When        RuleMatcher
 	Labels      map[string]RuleMatcher
 }
 
@@ -283,10 +284,15 @@ func parseRule(r map[string]interface{}) Rule {
 	if w, ok := r["what"]; ok {
 		what = ParseRuleMatcher("what", w.(string))
 	}
+	var when RuleMatcher
+	if w, ok := r["when"]; ok {
+		when = ParseRuleMatcher("when", w.(string))
+	}
 
 	br := Rule{
 		Description: r["description"].(string),
 		What:        what,
+		When:        when,
 		Labels:      labels,
 	}
 	return br

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -277,16 +277,16 @@ func parseRule(r map[string]interface{}) Rule {
 	labels := make(map[string]RuleMatcher)
 	if labelFilters, ok := r["label"]; ok {
 		for n, l := range labelFilters.(map[string]interface{}) {
-			labels[n] = ParseRuleMatcher(n, l.(string))
+			labels[n] = ParseRuleMatcher(l.(string))
 		}
 	}
 	var what RuleMatcher
 	if w, ok := r["what"]; ok {
-		what = ParseRuleMatcher("what", w.(string))
+		what = ParseRuleMatcher(w.(string))
 	}
 	var when RuleMatcher
 	if w, ok := r["when"]; ok {
-		when = ParseRuleMatcher("when", w.(string))
+		when = ParseRuleMatcher(w.(string))
 	}
 
 	br := Rule{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -57,8 +56,8 @@ type Dashboard struct {
 
 type Rule struct {
 	Description string
-	What        *regexp.Regexp
-	Labels      map[string]*regexp.Regexp
+	What        RuleMatcher
+	Labels      map[string]RuleMatcher
 }
 
 type mainConfig struct {
@@ -274,15 +273,15 @@ func (cfg *Config) loadDashboardConfig(file string) error {
 }
 
 func parseRule(r map[string]interface{}) Rule {
-	labels := make(map[string]*regexp.Regexp)
+	labels := make(map[string]RuleMatcher)
 	if labelFilters, ok := r["label"]; ok {
 		for n, l := range labelFilters.(map[string]interface{}) {
-			labels[n] = regexp.MustCompile(l.(string))
+			labels[n] = ParseRuleMatcher(n, l.(string))
 		}
 	}
-	var what *regexp.Regexp
+	var what RuleMatcher
 	if w, ok := r["what"]; ok {
-		what = regexp.MustCompile(w.(string))
+		what = ParseRuleMatcher("what", w.(string))
 	}
 
 	br := Rule{

--- a/pkg/config/rule_matching.go
+++ b/pkg/config/rule_matching.go
@@ -21,23 +21,21 @@ type RuleMatcher interface {
 
 func ParseRuleMatcher(label, s string) RuleMatcher {
 	if strings.HasPrefix(s, "~= ") {
-		return regexpMatcher{regexp.MustCompile(s)}
+		return regexpMatcher{regexp.MustCompile(s[3:])}
 	} else if strings.HasPrefix(s, "> ") {
-		return newNumberMatcher(gt, s)
-	} else if strings.HasPrefix(s, "> ") {
-		return newNumberMatcher(gt, s)
+		return newNumberMatcher(gt, s[2:])
 	} else if strings.HasPrefix(s, "= ") {
-		if _, err := strconv.ParseFloat(s, 64); err == nil {
-			return newNumberMatcher(eq, s)
+		if _, err := strconv.ParseFloat(s[2:], 64); err == nil {
+			return newNumberMatcher(eq, s[2:])
 		} else {
-			return equalityMatcher{s}
+			return equalityMatcher{s[2:]}
 		}
 	} else if strings.HasPrefix(s, ">= ") {
-		return newNumberMatcher(ge, s)
+		return newNumberMatcher(ge, s[3:])
 	} else if strings.HasPrefix(s, "< ") {
-		return newNumberMatcher(lt, s)
+		return newNumberMatcher(lt, s[2:])
 	} else if strings.HasPrefix(s, "<= ") {
-		return newNumberMatcher(le, s)
+		return newNumberMatcher(le, s[3:])
 	} else {
 		return regexpMatcher{regexp.MustCompile(s)}
 	}
@@ -73,15 +71,15 @@ func (m numberMatcher) MatchString(s string) bool {
 
 	switch m.operation {
 	case gt:
-		return floatEqualEnough(m.number, number) && m.number > number
+		return !floatEqualEnough(m.number, number) && number > m.number
 	case eq:
 		return floatEqualEnough(m.number, number)
 	case ge:
-		return floatEqualEnough(m.number, number) || m.number > number
+		return floatEqualEnough(m.number, number) || number > m.number
 	case lt:
-		return !floatEqualEnough(m.number, number) && m.number < number
+		return !floatEqualEnough(m.number, number) && number < m.number
 	case le:
-		return floatEqualEnough(m.number, number) || m.number > number
+		return floatEqualEnough(m.number, number) || number < m.number
 	}
 
 	return false

--- a/pkg/config/rule_matching.go
+++ b/pkg/config/rule_matching.go
@@ -1,19 +1,102 @@
 package config
 
-import "regexp"
+import (
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	gt = iota
+	eq
+	ge
+	lt
+	le
+)
 
 type RuleMatcher interface {
 	MatchString(s string) bool
+}
+
+func ParseRuleMatcher(label, s string) RuleMatcher {
+	if strings.HasPrefix(s, "~= ") {
+		return regexpMatcher{regexp.MustCompile(s)}
+	} else if strings.HasPrefix(s, "> ") {
+		return newNumberMatcher(gt, s)
+	} else if strings.HasPrefix(s, "> ") {
+		return newNumberMatcher(gt, s)
+	} else if strings.HasPrefix(s, "= ") {
+		if _, err := strconv.ParseFloat(s, 64); err == nil {
+			return newNumberMatcher(eq, s)
+		} else {
+			return equalityMatcher{s}
+		}
+	} else if strings.HasPrefix(s, ">= ") {
+		return newNumberMatcher(ge, s)
+	} else if strings.HasPrefix(s, "< ") {
+		return newNumberMatcher(lt, s)
+	} else if strings.HasPrefix(s, "<= ") {
+		return newNumberMatcher(le, s)
+	} else {
+		return regexpMatcher{regexp.MustCompile(s)}
+	}
 }
 
 type regexpMatcher struct {
 	r *regexp.Regexp
 }
 
-func (r regexpMatcher) MatchString(s string) bool {
-	return r.r.MatchString(s)
+func (m regexpMatcher) MatchString(s string) bool {
+	return m.r.MatchString(s)
 }
 
-func ParseRuleMatcher(k, v string) RuleMatcher {
-	return regexpMatcher{regexp.MustCompile(v)}
+type numberMatcher struct {
+	operation int
+	number    float64
+}
+
+func newNumberMatcher(op int, s string) numberMatcher {
+	number, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		panic("config parsing error")
+	}
+	return numberMatcher{op, number}
+}
+
+func (m numberMatcher) MatchString(s string) bool {
+	number, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		// an invalid number cannot be compared, thus returns as non-matching
+		return false
+	}
+
+	switch m.operation {
+	case gt:
+		return floatEqualEnough(m.number, number) && m.number > number
+	case eq:
+		return floatEqualEnough(m.number, number)
+	case ge:
+		return floatEqualEnough(m.number, number) || m.number > number
+	case lt:
+		return !floatEqualEnough(m.number, number) && m.number < number
+	case le:
+		return floatEqualEnough(m.number, number) || m.number > number
+	}
+
+	return false
+}
+
+const epsilon = 1e-8
+
+func floatEqualEnough(a, b float64) bool {
+	return math.Abs(a-b) <= epsilon
+}
+
+type equalityMatcher struct {
+	s string
+}
+
+func (m equalityMatcher) MatchString(s string) bool {
+	return m.s == s
 }

--- a/pkg/config/rule_matching.go
+++ b/pkg/config/rule_matching.go
@@ -1,0 +1,19 @@
+package config
+
+import "regexp"
+
+type RuleMatcher interface {
+	MatchString(s string) bool
+}
+
+type regexpMatcher struct {
+	r *regexp.Regexp
+}
+
+func (r regexpMatcher) MatchString(s string) bool {
+	return r.r.MatchString(s)
+}
+
+func ParseRuleMatcher(k, v string) RuleMatcher {
+	return regexpMatcher{regexp.MustCompile(v)}
+}


### PR DESCRIPTION
* Add a `when` rule to be able to match on when the alert happened.
* Add more expressive rules, making it possible to express a
  `greater than` on numerical values.  See `README` for details.
* Breaking configuration changes:
  * The `what` rules are now combined via `AND` with label rules.
    This streamlines the behaviour, making it behave like the label
    rules themselves.  It also makes it possible e.g. to express that
    a rule matcher only applies when the alert is old.

Rule changes:

* `what` rules will combine as `AND` with label rules.
* new `when` rules will combine with `AND` with label and `what` rules.

The default is to match the value in the configuration as a regular expression.
However, this can be changed by specifying an operator.
* `~= string`: Explicitly require a regular expression to be matched
* `= string`: Require the string to exactly match
* `> number`: Require both configuration and the value in the alert to be a
  numerical value and that the value in the alert to be bigger than the
  configured number.
  This also applies to the `<`, `>=`, `<=` operators.
