### PR TITLE
Linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 1.9.x
+
+* Using `tuwat -otelUrl stdout` or `TUWAT_OTEL_URL=stdout` now enables
+  tracing output on stdout.
+
 ## 1.8.0 - 2024-06-05 Icinga2 Host ACKs
 
 * Downtimes and acknowledgements as well as disabling notifications

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Connectors for
 
 ## Configuration
 
-See the [Example Config](./config.example.toml) for configuration.
+See the [Example Config](config.example.toml) for configuration.
 
 Available styles:
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,7 +153,7 @@ func NewConfiguration() (config *Config, err error) {
 
 	rootConfig := cfg.defaultConfiguration()
 
-	if err := cfg.loadConfigFile(*fConfigFile, &rootConfig); errors.Is(err, os.ErrNotExist) {
+	if err = cfg.loadConfigFile(*fConfigFile, &rootConfig); errors.Is(err, os.ErrNotExist) {
 		// ignore missing configuration and start with defaults
 		err = nil
 	} else if err != nil {

--- a/pkg/connectors/alertmanager/connector.go
+++ b/pkg/connectors/alertmanager/connector.go
@@ -62,7 +62,10 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 	}
 
 	for _, sourceAlert := range sourceAlerts {
-		severity, _ := sourceAlert.Labels["severity"]
+		severity := ""
+		if s, ok := sourceAlert.Labels["severity"]; ok {
+			severity = s
+		}
 
 		if sourceAlert.Status.State == "suppressed" {
 			continue

--- a/pkg/connectors/example/connector.go
+++ b/pkg/connectors/example/connector.go
@@ -2,7 +2,6 @@ package example
 
 import (
 	"context"
-	"fmt"
 	html "html/template"
 	"math/rand"
 	"time"
@@ -127,5 +126,5 @@ func exampleRandomAlert() connectors.Alert {
 }
 
 func (c *Connector) String() string {
-	return fmt.Sprintf("Example Connector")
+	return "Example Connector"
 }

--- a/pkg/connectors/github/connector_test.go
+++ b/pkg/connectors/github/connector_test.go
@@ -32,7 +32,7 @@ func TestConnector(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if alerts == nil || len(alerts) == 0 {
+	if len(alerts) == 0 {
 		t.Error("There should be alerts")
 	}
 }

--- a/pkg/connectors/gitlabmr/connector.go
+++ b/pkg/connectors/gitlabmr/connector.go
@@ -1,7 +1,6 @@
 package gitlabmr
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -152,18 +151,15 @@ func (c *Connector) collectMRsFrom(ctx context.Context, from string) ([]mergeReq
 		}
 		defer body.Close()
 
-		b, _ := io.ReadAll(body)
-		buf := bytes.NewBuffer(b)
-
-		decoder := json.NewDecoder(buf)
+		decoder := json.NewDecoder(body)
 
 		var mrs []mergeRequest
 		err = decoder.Decode(&mrs)
 		if err != nil {
 			slog.ErrorContext(ctx, "Cannot parse",
 				slog.String("url", c.config.URL+from),
-				slog.String("data", buf.String()),
-				slog.Any("error", err))
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
 		mergeRequests = append(mergeRequests, mrs...)

--- a/pkg/connectors/orderview/connector.go
+++ b/pkg/connectors/orderview/connector.go
@@ -46,7 +46,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 
 	for _, sourceAlert := range sourceAlerts {
 
-		state := connectors.Warning
+		var state connectors.State
 		switch sourceAlert.State {
 		case 2:
 			state = connectors.Critical

--- a/pkg/connectors/patchman/connector.go
+++ b/pkg/connectors/patchman/connector.go
@@ -54,7 +54,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 	var alerts []connectors.Alert
 
 	for _, host := range hosts {
-		if host.SecurityUpdateCount == 0 && host.RebootRequired == false {
+		if host.SecurityUpdateCount == 0 && !host.RebootRequired {
 			continue
 		}
 

--- a/pkg/connectors/patchman/connector.go
+++ b/pkg/connectors/patchman/connector.go
@@ -66,9 +66,9 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 		details := fmt.Sprintf("Security Updates: %d, Updates: %d, Needs Reboot: %t",
 			host.SecurityUpdateCount, host.BugfixUpdateCount, host.RebootRequired)
 
-		os, err := getCached(ctx, c, c.osCache, host.OSURL)
-		arch, err := getCached(ctx, c, c.archCache, host.ArchURL)
-		domain, err := getCached(ctx, c, c.domainCache, host.DomainURL)
+		os, _ := getCached(ctx, c, c.osCache, host.OSURL)
+		arch, _ := getCached(ctx, c, c.archCache, host.ArchURL)
+		domain, _ := getCached(ctx, c, c.domainCache, host.DomainURL)
 
 		alert := connectors.Alert{
 			Labels: map[string]string{

--- a/pkg/connectors/patchman/connector.go
+++ b/pkg/connectors/patchman/connector.go
@@ -121,10 +121,6 @@ func (c *Connector) collectHosts(ctx context.Context) ([]host, error) {
 			// Paging necessary
 		pageHandler:
 			for t, err := decoder.Token(); err == nil; t, err = decoder.Token() {
-				if err != nil {
-					slog.ErrorContext(ctx, "Cannot parse", slog.Any("error", err))
-				}
-
 				if s, ok := t.(string); ok && s == "next" {
 					s, err := decoder.Token()
 					if s, ok := s.(string); ok && err == nil {

--- a/pkg/connectors/patchman/connector.go
+++ b/pkg/connectors/patchman/connector.go
@@ -160,8 +160,7 @@ func (c *Connector) collectHosts(ctx context.Context) ([]host, error) {
 		}
 
 		// read closing bracket
-		t, err = decoder.Token()
-		if err != nil {
+		if _, err := decoder.Token(); err != nil {
 			slog.ErrorContext(ctx, "Cannot parse", slog.Any("error", err))
 			return nil, err
 		}

--- a/pkg/log/telemetry.go
+++ b/pkg/log/telemetry.go
@@ -25,7 +25,9 @@ import (
 func InitializeTracer(appCtx context.Context, cfg *config.Config) trace.Tracer {
 	var tp *tracesdk.TracerProvider
 
-	if cfg.OtelUrl != "" {
+	if cfg.OtelUrl == "stdout" {
+		tp = stdoutTracer(cfg)
+	} else if cfg.OtelUrl != "" {
 		tp = otelHttpTracer(appCtx, cfg)
 	} else {
 		tp = noopTracer()

--- a/pkg/web/actuator/checker_test.go
+++ b/pkg/web/actuator/checker_test.go
@@ -22,6 +22,6 @@ func TestNewHealthAccumulator(t *testing.T) {
 	cancel()
 }
 
-func testCheck(ctx context.Context) (status Status, message string) {
+func testCheck(context.Context) (status Status, message string) {
 	return Up, "test"
 }

--- a/pkg/web/api/alertmanager/web.go
+++ b/pkg/web/api/alertmanager/web.go
@@ -112,12 +112,12 @@ func (h *alertmanagerHandler) alerts(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if active == false {
+	if !active {
 		gettableAlerts = slices.DeleteFunc(gettableAlerts, func(x gettableAlert) bool {
 			return x.Status.State == "active"
 		})
 	}
-	if inhibited == false {
+	if !inhibited {
 		gettableAlerts = slices.DeleteFunc(gettableAlerts, func(x gettableAlert) bool {
 			return x.Status.State == "suppressed"
 		})

--- a/pkg/web/handler.go
+++ b/pkg/web/handler.go
@@ -13,7 +13,7 @@ import (
 func Handle(appCtx context.Context, cfg *config.Config, webHandler, alertmanagerApi http.Handler) {
 	muxer := newTracedMuxer()
 
-	muxer.Handle("static", "/static/", http.StripPrefix("/static", newNoListingFileServer(cfg)))
+	muxer.Handle("static", "/static/", http.StripPrefix("/static", newNoListingFileServer()))
 	muxer.Handle("api", "/api/alertmanager/", http.StripPrefix("/api/alertmanager", alertmanagerApi))
 	muxer.Handle("web", "/", webHandler)
 

--- a/pkg/web/static.go
+++ b/pkg/web/static.go
@@ -8,14 +8,12 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-
-	"github.com/synyx/tuwat/pkg/config"
 )
 
 //go:embed static
 var content embed.FS
 
-func newNoListingFileServer(cfg *config.Config) http.Handler {
+func newNoListingFileServer() http.Handler {
 	var staticFS fs.FS
 
 	if dir, ok := os.LookupEnv("TUWAT_STATICDIR"); ok {

--- a/pkg/web/static.go
+++ b/pkg/web/static.go
@@ -41,8 +41,7 @@ func (nfs noListingFS) Open(path string) (http.File, error) {
 		return nil, err
 	}
 
-	s, err := f.Stat()
-	if s.IsDir() {
+	if s, err := f.Stat(); err == nil && s.IsDir() {
 		index := filepath.Join(path, "index.html")
 		if _, err := nfs.fs.Open(index); err != nil {
 			closeErr := f.Close()


### PR DESCRIPTION
Run `golangci-lint` to keep the codebase clean.