### PR TITLE
patchman, enable filtering hosts

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -60,6 +60,7 @@ Tag = 'demo'
 #Insecure = true
 #Username = "user"
 #Password = "password"
+#Filter = { tag = "test", domain = "1", os = "7", osgroup = "2", arch = "5", reboot_required = "True" }
 #
 #[[redmine]]
 #Tag = "tkt"

--- a/pkg/connectors/patchman/connector.go
+++ b/pkg/connectors/patchman/connector.go
@@ -27,7 +27,8 @@ type Connector struct {
 }
 
 type Config struct {
-	Tag string
+	Tag    string
+	Filter map[string]string
 	common.HTTPConfig
 }
 
@@ -200,6 +201,12 @@ func (c *Connector) get(ctx context.Context, endpoint string) (io.ReadCloser, er
 	if err != nil {
 		return nil, err
 	}
+
+	q := req.URL.Query()
+	for k, v := range c.config.Filter {
+		q.Set(k, v)
+	}
+	req.URL.RawQuery = q.Encode()
 
 	req.Header.Set("Accept", "application/json")
 	if c.config.Username != "" {


### PR DESCRIPTION
Enables pre-filtering when getting Patchman Hosts.  This reduces the amount of data transferred massively in some instances.