### PR TITLE
Icinga2 hoststate

### DIFF
--- a/pkg/connectors/icinga2/connector.go
+++ b/pkg/connectors/icinga2/connector.go
@@ -210,13 +210,18 @@ func (c *Connector) get(endpoint string, ctx context.Context) (io.ReadCloser, er
 	return nil, fmt.Errorf("failed to get, unknown status code: %d", res.StatusCode)
 }
 
+// see: https://icinga.com/docs/icinga-2/latest/doc/03-monitoring-basics/#check-result-state-mapping
 func fromHostState(state int) connectors.State {
 	switch state {
-	case 0:
+	case 0: // OK
+		fallthrough
+	case 1: // WARNING
+		// both OK and WARNING mean that the host generally is considered UP.
 		return connectors.OK
-	case 1:
-		return connectors.Critical
-	case 2:
+	case 2: // CRITICAL
+		fallthrough
+	case 3: // UNKNOWN
+		// bot CRITICAL and UNKNOWN are considered DOWN for hosts by icinga2.
 		return connectors.Critical
 	}
 	return connectors.Unknown

--- a/pkg/connectors/icinga2/connector.go
+++ b/pkg/connectors/icinga2/connector.go
@@ -74,7 +74,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 				"Type":     "Host",
 			},
 			Start:       time.Unix(int64(sec), int64(dec*(1e9))),
-			State:       connectors.State(host.State),
+			State:       fromHostState(host.State),
 			Description: "Host down",
 			Details:     host.Output,
 			Links: []html.HTML{
@@ -115,7 +115,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 				"Type":       "Service",
 			},
 			Start:       time.Unix(int64(sec), int64(dec*(1e9))),
-			State:       connectors.State(service.State),
+			State:       fromServiceState(service.State),
 			Description: service.DisplayName,
 			Details:     service.LastCheckResult.Output,
 			Links: []html.HTML{
@@ -208,4 +208,20 @@ func (c *Connector) get(endpoint string, ctx context.Context) (io.ReadCloser, er
 	}
 
 	return nil, fmt.Errorf("failed to get, unknown status code: %d", res.StatusCode)
+}
+
+func fromHostState(state int) connectors.State {
+	switch state {
+	case 0:
+		return connectors.OK
+	case 1:
+		return connectors.Critical
+	case 2:
+		return connectors.Critical
+	}
+	return connectors.Unknown
+}
+
+func fromServiceState(state int) connectors.State {
+	return connectors.State(state)
 }

--- a/pkg/connectors/nagiosapi/connector.go
+++ b/pkg/connectors/nagiosapi/connector.go
@@ -64,7 +64,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 					"Type":     "Host",
 				},
 				Start:       time.Unix(stateChange, 0),
-				State:       connectors.State(state),
+				State:       fromHostState(state),
 				Description: "Host down",
 				Details:     host.PluginOutput,
 				Links: []html.HTML{
@@ -103,7 +103,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 					"Type":     "Service",
 				},
 				Start:       time.Unix(stateChange, 0),
-				State:       connectors.State(state),
+				State:       fromServiceState(state),
 				Description: serviceName,
 				Details:     service.PluginOutput,
 				Links: []html.HTML{
@@ -149,4 +149,24 @@ func (c *Connector) collectHosts(ctx context.Context) (map[string]host, error) {
 	}
 
 	return response.Content, nil
+}
+
+func fromHostState(state int64) connectors.State {
+	switch state {
+	case 0:
+		return connectors.OK
+	case 1:
+		// assumption: 0 = Don't use aggressive host checking (default)
+		// this means we should treat this as OK, however, be cautious.
+		return connectors.Warning
+	case 2:
+		return connectors.Critical
+	case 3:
+		return connectors.Critical
+	}
+	return connectors.Unknown
+}
+
+func fromServiceState(state int64) connectors.State {
+	return connectors.State(state)
 }

--- a/pkg/connectors/orderview/connector.go
+++ b/pkg/connectors/orderview/connector.go
@@ -46,15 +46,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 
 	for _, sourceAlert := range sourceAlerts {
 
-		var state connectors.State
-		switch sourceAlert.State {
-		case 2:
-			state = connectors.Critical
-		case 1:
-			state = connectors.Warning
-		default:
-			state = connectors.Unknown
-		}
+		state := fromSourceState(sourceAlert.State)
 
 		alert := connectors.Alert{
 			Labels: map[string]string{
@@ -118,4 +110,15 @@ func (c *Connector) get(ctx context.Context, endpoint string) (*http.Response, e
 	}
 
 	return res, nil
+}
+
+func fromSourceState(state int) connectors.State {
+	switch state {
+	case 2:
+		return connectors.Critical
+	case 1:
+		return connectors.Warning
+	default:
+		return connectors.Unknown
+	}
 }

--- a/pkg/connectors/patchman/connector.go
+++ b/pkg/connectors/patchman/connector.go
@@ -88,18 +88,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 			}
 		}
 
-		state := connectors.Unknown
-		description := "Host Updates"
-		if host.SecurityUpdateCount > 0 {
-			state = connectors.Critical
-			description = fmt.Sprintf("Host Security Updates missing: %d", host.SecurityUpdateCount)
-		} else if host.BugfixUpdateCount > 0 {
-			state = connectors.Warning
-			description = fmt.Sprintf("Host Bugfix Updates missing: %d", host.BugfixUpdateCount)
-		} else if host.RebootRequired {
-			state = connectors.Warning
-			description = "Host Reboot Required"
-		}
+		state, description := fromHostState(host)
 
 		alert := connectors.Alert{
 			Labels: map[string]string{
@@ -253,4 +242,20 @@ func (c *Connector) get(ctx context.Context, endpoint string) (io.ReadCloser, er
 	}
 
 	return res.Body, nil
+}
+
+func fromHostState(host host) (connectors.State, string) {
+	state := connectors.Unknown
+	description := "Host Updates"
+	if host.SecurityUpdateCount > 0 {
+		state = connectors.Critical
+		description = fmt.Sprintf("Host Security Updates missing: %d", host.SecurityUpdateCount)
+	} else if host.BugfixUpdateCount > 0 {
+		state = connectors.Warning
+		description = fmt.Sprintf("Host Bugfix Updates missing: %d", host.BugfixUpdateCount)
+	} else if host.RebootRequired {
+		state = connectors.Warning
+		description = "Host Reboot Required"
+	}
+	return state, description
 }

--- a/pkg/connectors/redmine/connector.go
+++ b/pkg/connectors/redmine/connector.go
@@ -51,10 +51,7 @@ func (c *Connector) Collect(ctx context.Context) ([]connectors.Alert, error) {
 			continue
 		}
 
-		state := connectors.Critical
-		if issue.DueDate == time.Now().Format("2006-01-02") {
-			state = connectors.Warning
-		}
+		state := fromSourceIssue(issue)
 
 		alert := connectors.Alert{
 			Labels: map[string]string{
@@ -124,4 +121,12 @@ func (c *Connector) collectIssues(ctx context.Context) ([]issue, error) {
 	}
 
 	return response.Issues, nil
+}
+
+func fromSourceIssue(issue issue) connectors.State {
+	state := connectors.Critical
+	if issue.DueDate == time.Now().Format("2006-01-02") {
+		state = connectors.Warning
+	}
+	return state
 }


### PR DESCRIPTION
Icinga2/Nagios host states were not parsed correctly.

* https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html (https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/configmain.html#use_aggressive_host_checking)
* https://icinga.com/docs/icinga-2/latest/doc/03-monitoring-basics/

This also refactors the other connectors to look similarly.