### PR TITLE
Added config to allow grouping of alerts by the "Where" column

### DIFF
--- a/cmd/tuwat/main.go
+++ b/cmd/tuwat/main.go
@@ -43,7 +43,7 @@ func main() {
 	acc.Register("aggregation", aggregation.NewAggregatorHealthCheck(aggregator))
 
 	go web.Handle(appCtx, cfg, webHandler, alertmanagerApi)
-	go aggregator.Run(appCtx)
+	go aggregator.Run(appCtx, cfg)
 	go acc.Run(appCtx)
 	go actuator.Handle(appCtx, cfg)
 

--- a/cmd/tuwat/main.go
+++ b/cmd/tuwat/main.go
@@ -43,7 +43,7 @@ func main() {
 	acc.Register("aggregation", aggregation.NewAggregatorHealthCheck(aggregator))
 
 	go web.Handle(appCtx, cfg, webHandler, alertmanagerApi)
-	go aggregator.Run(appCtx, cfg)
+	go aggregator.Run(appCtx)
 	go acc.Run(appCtx)
 	go actuator.Handle(appCtx, cfg)
 

--- a/pkg/aggregation/aggregator_test.go
+++ b/pkg/aggregation/aggregator_test.go
@@ -88,7 +88,7 @@ func aggregate(a *Aggregator, t *testing.T) Aggregate {
 		t.Fatal("Make sure nr == number in mock Collect()", results)
 	}
 
-	a.aggregate(ctx, a.dashboards["Home"], results)
+	a.aggregate(ctx, nil, a.dashboards["Home"], results)
 
 	return a.current["Home"]
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	OtelUrl        string
 	Instance       string
 	PrintVersion   bool
+	GroupAlerts    bool
 	Connectors     []connectors.Connector
 	WhereTemplate  *template.Template
 	Interval       time.Duration
@@ -67,6 +68,7 @@ type mainConfig struct {
 	WhereTemplate string `toml:"where"`
 	Interval      string `toml:"interval"`
 	Style         string `toml:"style"`
+	GroupAlerts   bool   `toml:"group_alerts"`
 }
 
 type mainDashboardConfig struct {
@@ -193,6 +195,7 @@ func (cfg *Config) defaultConfiguration() rootConfig {
 
 	rootConfig.Main.Interval = "1m"
 	rootConfig.Main.Style = "dark"
+	rootConfig.Main.GroupAlerts = false
 
 	return rootConfig
 }
@@ -212,6 +215,7 @@ func (cfg *Config) loadConfigFile(file string, rootConfig *rootConfig) error {
 
 func (cfg *Config) configureMain(rootConfig *rootConfig) (err error) {
 	cfg.Style = rootConfig.Main.Style
+	cfg.GroupAlerts = rootConfig.Main.GroupAlerts
 
 	// Add connectors
 	for _, connectorConfig := range rootConfig.Alertmanagers {

--- a/pkg/web/api/alertmanager/web.go
+++ b/pkg/web/api/alertmanager/web.go
@@ -103,6 +103,15 @@ func (h *alertmanagerHandler) alerts(w http.ResponseWriter, r *http.Request) {
 
 			gettableAlerts = append(gettableAlerts, mapAlert(dashboard.Name, aggregate, alert, "active"))
 		}
+		for _, alertGroup := range aggregate.GroupedAlerts {
+			for _, alert := range alertGroup.Alerts {
+				if alert.Status == "green" {
+					continue
+				}
+
+				gettableAlerts = append(gettableAlerts, mapAlert(dashboard.Name, aggregate, alert, "active"))
+			}
+		}
 		for _, alert := range aggregate.Blocked {
 			if alert.Status == "green" {
 				continue

--- a/pkg/web/static/css/light.css
+++ b/pkg/web/static/css/light.css
@@ -3,8 +3,11 @@ body {
     color: #333333;
 }
 
-table               { border: 1px solid #c6c6c6; background-color: #F0F0F0; border-collapse: separate;
-    *border-collapse: collapse; -webkit-border-radius: 4px;
+table               {
+    border: 1px solid #c6c6c6;
+    background-color: #F0F0F0;
+    border-collapse: collapse;
+    -webkit-border-radius: 4px;
     -moz-border-radius: 4px; border-radius: 4px; }
 th {
     background-color: #D8D8D8;

--- a/pkg/web/static/css/main.css
+++ b/pkg/web/static/css/main.css
@@ -16,7 +16,6 @@ h3 {
 }
 
 table, td {
-    border: none;
     border-collapse: collapse;
     padding: 3px;
     font-size: 1.1em;
@@ -26,11 +25,15 @@ table {
     border-spacing: 0;
     background: #242222;
     border: 1px solid transparent;
-    border-collapse: separate;
-    *border-collapse: collapse;
+    border-collapse: collapse;
     -webkit-border-radius: 4px;
     -moz-border-radius: 4px;
     border-radius: 4px;
+}
+
+table tbody {
+    vertical-align: top;
+    border: 1px solid black;
 }
 
 th {

--- a/pkg/web/templates/alerts.gohtml
+++ b/pkg/web/templates/alerts.gohtml
@@ -15,28 +15,57 @@
     </thead>
     <tbody>
     {{range .Content.Alerts}}
-    <tr>
-        <td>
-            {{.Where}} <span class="tag {{.Tag}}">{{.Tag}}</span>
-        </td>
-        <td class="status {{.Status}}">
-            <details>
-                <summary>
-                    {{.What}}
-                    {{range .Links}}
-                        {{.}}
-                    {{end}}
-                </summary>
-                <div class="content">
-                    <div>{{.Details}}</div>
-                    <pre>{{json .Labels}}</pre>
-                </div>
-            </details>
-        </td>
-        <td align="right"><time datetime="{{.When.Seconds}}S">{{niceDuration .When}}</time></td>
-    </tr>
+        <tr>
+            <td>
+                {{.Where}} <span class="tag {{.Tag}}">{{.Tag}}</span>
+            </td>
+            <td class="status {{.Status}}">
+                <details>
+                    <summary>
+                        {{.What}}
+                        {{range .Links}}
+                            {{.}}
+                        {{end}}
+                    </summary>
+                    <div class="content">
+                        <div>{{.Details}}</div>
+                        <pre>{{json .Labels}}</pre>
+                    </div>
+                </details>
+            </td>
+            <td align="right"><time datetime="{{.When.Seconds}}S">{{niceDuration .When}}</time></td>
+        </tr>
     {{end}}
     </tbody>
+    {{range .Content.GroupedAlerts}}
+    <tbody>
+        <tr>
+            <td rowspan="{{len .Alerts}}">
+                {{.Where}} <span class="tag {{.Tag}}">{{.Tag}}</span>
+            </td>
+        {{range $i, $alert := .Alerts}}
+            {{if $i }}
+        <tr>
+            {{end}}
+            <td class="status {{$alert.Status}}">
+                <details>
+                    <summary>
+                        {{$alert.What}}
+                        {{range $alert.Links}}
+                            {{.}}
+                        {{end}}
+                    </summary>
+                    <div class="content">
+                        <div>{{$alert.Details}}</div>
+                        <pre>{{json $alert.Labels}}</pre>
+                    </div>
+                </details>
+            </td>
+            <td align="right"><time datetime="{{$alert.When.Seconds}}S">{{niceDuration $alert.When}}</time></td>
+        </tr>
+        {{end}}
+    </tbody>
+    {{end}}
 </table>
 
 <h3 class="filtered">


### PR DESCRIPTION
By default, the display of the alerts will be as usual, one line per alert:

![image](https://github.com/user-attachments/assets/aac1ddf8-564b-4720-8303-714e74a11868)

When group_alerts in [main] is set to true, alerts will be grouped by `Where` and `tag` values:

![image](https://github.com/user-attachments/assets/7410877e-3770-4d1b-89dd-9db96a18ecb2)

![image](https://github.com/user-attachments/assets/101b1064-6325-437c-bdfe-05002718e841)
